### PR TITLE
Define abstract classes for the city object types

### DIFF
--- a/example-datasets/dummy-values/example.json
+++ b/example-datasets/dummy-values/example.json
@@ -30,7 +30,8 @@
         "measuredHeight": 22.3,
         "roofType": "gable",
         "yearOfConstruction": 1904,
-        "owner": "Elvis Presley"
+        "owner": "Elvis Presley",
+        "creationDate": "2018 11 14"
       },
       "geographicalExtent": [ 84710, 446846, -5, 84757, 446944, 40 ],
       "address": {

--- a/example-datasets/dummy-values/example.json
+++ b/example-datasets/dummy-values/example.json
@@ -168,11 +168,11 @@
       "type": "Building", 
       "attributes": { 
         "measuredHeight": 223,
-        "function": 222
+        "function": "222"
       },
       "children": ["801"],
       "geometry": [{
-        "type": "MultiSurfaces",
+        "type": "MultiSurface",
         "lod": 2,
         "boundaries": [ 
            [[0, 3, 2, 1]], [[4, 5, 6, 7]], [[0, 1, 5, 4]], [[1, 2, 6, 5]], [[2, 3, 7, 6]], [[3, 0, 4, 7]]

--- a/example-datasets/dummy-values/example.json
+++ b/example-datasets/dummy-values/example.json
@@ -32,6 +32,7 @@
         "yearOfConstruction": 1904,
         "owner": "Elvis Presley"
       },
+      "geographicalExtent": [ 84710, 446846, -5, 84757, 446944, 40 ],
       "address": {
         "CountryName": "Canada",
         "LocalityName": "Chibougamau",
@@ -150,6 +151,9 @@
     },    
     "onebigtree-template": {
       "type": "SolitaryVegetationObject", 
+      "attributes": {
+        "measuredHeight": 223    
+      },
       "geometry": [
         {
           "type": "GeometryInstance",

--- a/example-datasets/dummy-values/example.json
+++ b/example-datasets/dummy-values/example.json
@@ -127,7 +127,8 @@
     "2929": {
       "type": "BuildingPart", 
       "attributes": {
-        "renovation": "2001/09/11"
+        "renovation": "2001/09/11",
+        "yearOfConstruction": 2912
       },
       "parent": "102636712",
       "geometry": [{

--- a/example-datasets/dummy-values/example.json
+++ b/example-datasets/dummy-values/example.json
@@ -167,11 +167,12 @@
     "itcanbeastringtoo": {
       "type": "Building", 
       "attributes": { 
-        "measuredHeight": 223
+        "measuredHeight": 223,
+        "function": 222
       },
       "children": ["801"],
       "geometry": [{
-        "type": "MultiSurface",
+        "type": "MultiSurfaces",
         "lod": 2,
         "boundaries": [ 
            [[0, 3, 2, 1]], [[4, 5, 6, 7]], [[0, 1, 5, 4]], [[1, 2, 6, 5]], [[2, 3, 7, 6]], [[3, 0, 4, 7]]

--- a/schema/v09/cityjson.json
+++ b/schema/v09/cityjson.json
@@ -18,7 +18,7 @@
       "type": "object",
       "additionalProperties": { 
         "type": "string",
-        "pattern": "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
+        "format": "uri-reference",
         "description": "the string needs to be a URI"
       }
     },

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -412,78 +412,74 @@
   },
 
   "_AbstractBuilding": {
-    "allof": [
-      { "$ref" : "#/_AbstractCityObject" },
-      {
+    "properties": {
+      "attributes": {
         "properties": {
-          "attributes": {
-            "properties": {
-              "measuredHeight": { "type": "number"},
-              "roofType": { "type": "string"},
-              "storeysAboveGround": { "type": "integer"},
-              "storeysBelowGround": { "type": "integer"},
-              "storeyHeightsAboveGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "storeyHeightsBelowGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "yearOfConstruction": { "type": "integer"},
-              "yearOfDemolition": { "type": "integer"}
-            }
-          },
-          "address": {
-            "type": "object",
-            "properties": {
-              "CountryName": {"type": "string"},
-              "LocalityName": {"type": "string"},
-              "ThoroughfareNumber": {"type": "string"},
-              "ThoroughfareName": {"type": "string"},
-              "PostalCode": {"type": "string"},
-              "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-            }
-          },
-          "children": {
+          "measuredHeight": { "type": "number"},
+          "roofType": { "type": "string"},
+          "storeysAboveGround": { "type": "integer"},
+          "storeysBelowGround": { "type": "integer"},
+          "storeyHeightsAboveGround": { 
             "type": "array",
-            "description": "the IDs of the BuildingPart/Installation of this Building",
-            "items": {"type": "string"}
+            "items": {"type": "number"}
           },
-          "geographicalExtent": {
+          "storeyHeightsBelowGround": { 
             "type": "array",
-            "items": { "type": "number" },
-            "minItems": 6,    
-            "maxItems": 6    
+            "items": {"type": "number"}
           },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"$ref": "geomprimitives.json#/Solid"},
-                {"$ref": "geomprimitives.json#/CompositeSolid"},
-                {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomtemplates.json#/GeometryInstance"}
-              ] 
-            }
-          }
-        },
-        "required": ["geometry"]
+          "yearOfConstruction": { "type": "integer"},
+          "yearOfDemolition": { "type": "integer"}
+        }
+      },
+      "address": {
+        "type": "object",
+        "properties": {
+          "CountryName": {"type": "string"},
+          "LocalityName": {"type": "string"},
+          "ThoroughfareNumber": {"type": "string"},
+          "ThoroughfareName": {"type": "string"},
+          "PostalCode": {"type": "string"},
+          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+        }
+      },
+      "children": {
+        "type": "array",
+        "description": "the IDs of the BuildingPart/Installation of this Building",
+        "items": {"type": "string"}
+      },
+      "geographicalExtent": {
+        "type": "array",
+        "items": { "type": "number" },
+        "minItems": 6,    
+        "maxItems": 6    
+      },
+      "geometry": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {"$ref": "geomprimitives.json#/Solid"},
+            {"$ref": "geomprimitives.json#/CompositeSolid"},
+            {"$ref": "geomprimitives.json#/MultiSurface"},
+            {"$ref": "geomtemplates.json#/GeometryInstance"}
+          ] 
+        }
       }
-    ]
+    }
   },
+
   
   "Building": {
-    "allOf": [
-      { "$ref" : "#/_AbstractBuilding" },
-      {
-        "properties": {
-          "type": { "enum": ["Building"] }
-        },
-        "required": ["type"]
-      }
-    ]
+    "allOf": [ 
+      { "$ref" : "#/_AbstractCityObject" }, 
+      { "$ref" : "#/_AbstractBuilding" }
+    ],
+    "properties": {
+      "type": { "enum": ["Building"] },
+      "geometry": {}
+    },
+    "required": ["type", "geometry"]
   },
+
 
   "BuildingPart": {
     "allOf": [

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -407,9 +407,16 @@
           "function": {"type": "string"},
           "usage": {"type": "string"}
         }
+      },
+      "geographicalExtent": {
+        "type": "array",
+        "items": { "type": "number" },
+        "minItems": 6,    
+        "maxItems": 6    
       }
     }
   },
+
 
   "_AbstractBuilding": {
     "properties": {
@@ -447,12 +454,6 @@
         "description": "the IDs of the BuildingPart/Installation of this Building",
         "items": {"type": "string"}
       },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
       "geometry": {
         "type": "array",
         "items": {
@@ -468,18 +469,14 @@
     "required": ["geometry"]
   },
   
+
   "Building": {
     "allOf": [
       { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBuilding" },
       {
         "properties": {
-          "type": { "enum": ["Building"] },
-          "attributes": {
-            "properties": {
-              "test": {"type": "string"}
-            }
-          }
+          "type": { "enum": ["Building"] }
         },
         "required": ["type"]
       }
@@ -488,62 +485,82 @@
 
   "BuildingPart": {
     "allOf": [
-      { "$ref": "#/_AbstractBuilding" }
-    ],
-    "properties": {
-      "type": { "enum": ["BuildingPart"] },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Building"
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractBuilding" },
+      {
+        "properties": {
+          "type": { "enum": ["BuildingPart"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          }
+        },
+        "required": ["type", "parent"]
       }
-    },
-    "required": ["parent"]
+    ]
   },
+
 
   "BuildingInstallation": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["BuildingInstallation"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Tunnel"
-      },
-
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},            
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["BuildingInstallation"] },
+          "attributes": {
+            "properties": {
+              "measuredHeight": { "type": "number"},
+              "roofType": { "type": "string"},
+              "storeysAboveGround": { "type": "integer"},
+              "storeysBelowGround": { "type": "integer"},
+              "storeyHeightsAboveGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "storeyHeightsBelowGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "yearOfConstruction": { "type": "integer"},
+              "yearOfDemolition": { "type": "integer"}
+            }
+          },
+          "address": {
+            "type": "object",
+            "properties": {
+              "CountryName": {"type": "string"},
+              "LocalityName": {"type": "string"},
+              "ThoroughfareNumber": {"type": "string"},
+              "ThoroughfareName": {"type": "string"},
+              "PostalCode": {"type": "string"},
+              "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+            }
+          },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},            
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["type", "geometry" , "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
+    ]
   },
+
 
   "Road": {
     "type": "object",

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -76,10 +76,9 @@
         "type": "array",
         "items": {
           "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
             {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
+            {"$ref": "geomprimitives.json#/Solid"},
+            {"$ref": "geomprimitives.json#/CompositeSolid"}
           ] 
         }
       }
@@ -220,10 +219,9 @@
         "type": "array",
         "items": {
           "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
             {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
+            {"$ref": "geomprimitives.json#/Solid"},
+            {"$ref": "geomprimitives.json#/CompositeSolid"}
           ] 
         }
       }
@@ -293,209 +291,131 @@
       }
     ]
   },
- 
+
+
+  "_AbstractBridge": {
+    "properties": {
+      "attributes": {
+        "properties": {
+          "yearOfConstruction": {"type": "integer"},
+          "yearOfDemolition": {"type": "integer"},
+          "isMovable": {"type": "boolean" }
+        }
+      },
+      "children": {
+        "type": "array",
+        "description": "the IDs of the Bridge/Part/Installation/CE of this Bridge",
+        "items": {"type": "string"}
+      },
+      "geometry": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {"$ref": "geomprimitives.json#/MultiSurface"},
+            {"$ref": "geomprimitives.json#/Solid"},
+            {"$ref": "geomprimitives.json#/CompositeSolid"}
+          ] 
+        }
+      }
+    },
+    "required": ["geometry"]
+  },
+  
 
   "Bridge": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["Bridge"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractBridge" },
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"},
-          "isMovable": { "type": "boolean"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the BridgePart/Installation/ConstructionElement of this Bridge",
-        "items": {"type": "string"}
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["Bridge"] }
+        },
+        "required": ["type"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
-  },    
+    ]
+  }, 
+
 
   "BridgePart": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["BridgePart"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractBridge" },
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"},
-          "isMovable": { "type": "boolean"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the BridgeInstallation/ConstructionElement of this BridgePart",
-        "items": {"type": "string"}
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Bridge"
-      },      
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["BridgePart"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          }
+        },
+        "required": ["type", "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
+    ]
   },
+
 
   "BridgeInstallation": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["BridgeInstallation"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string","format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Bridge"
-      },      
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}            
-          ] 
-        }
+          "type": { "enum": ["BridgeInstallation"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Bridge"
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},            
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["type", "geometry" , "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
-  },
+    ]
+  },    
+
 
   "BridgeConstructionElement": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["BridgeConstructionElement"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Bridge"
-      },      
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},            
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["BridgeConstructionElement"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Bridge"
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},            
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["type", "geometry" , "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
-  },
+    ]
+  }, 
 
 
   "Road": {

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -395,7 +395,7 @@
     "additionalProperties": false
   },
 
-  "_AbstractBuilding": {
+  "_AbstractCityObject": {
     "type": "object",
     "properties": {
       "attributes": {
@@ -405,63 +405,77 @@
           "terminationDate" : {"type": "string", "format": "date"},
           "class": {"type": "string"},
           "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "measuredHeight": { "type": "number"},
-          "roofType": { "type": "string"},
-          "storeysAboveGround": { "type": "integer"},
-          "storeysBelowGround": { "type": "integer"},
-          "storeyHeightsAboveGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "storeyHeightsBelowGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the BuildingPart/Installation of this Building",
-        "items": {"type": "string"}
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
+          "usage": {"type": "string"}
         }
       }
-    },
-    "required": ["geometry"]
+    }
   },
 
+  "_AbstractBuilding": {
+    "allof": [
+      { "$ref" : "#/_AbstractCityObject" },
+      {
+        "properties": {
+          "attributes": {
+            "properties": {
+              "measuredHeight": { "type": "number"},
+              "roofType": { "type": "string"},
+              "storeysAboveGround": { "type": "integer"},
+              "storeysBelowGround": { "type": "integer"},
+              "storeyHeightsAboveGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "storeyHeightsBelowGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "yearOfConstruction": { "type": "integer"},
+              "yearOfDemolition": { "type": "integer"}
+            }
+          },
+          "address": {
+            "type": "object",
+            "properties": {
+              "CountryName": {"type": "string"},
+              "LocalityName": {"type": "string"},
+              "ThoroughfareNumber": {"type": "string"},
+              "ThoroughfareName": {"type": "string"},
+              "PostalCode": {"type": "string"},
+              "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+            }
+          },
+          "children": {
+            "type": "array",
+            "description": "the IDs of the BuildingPart/Installation of this Building",
+            "items": {"type": "string"}
+          },
+          "geographicalExtent": {
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 6,    
+            "maxItems": 6    
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["geometry"]
+      }
+    ]
+  },
+  
   "Building": {
     "allOf": [
-      { "$ref" : "#/_AbstractBuilding"},
+      { "$ref" : "#/_AbstractBuilding" },
       {
         "properties": {
           "type": { "enum": ["Building"] }

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -395,8 +395,8 @@
     "additionalProperties": false
   },
 
+
   "_AbstractCityObject": {
-    "type": "object",
     "properties": {
       "attributes": {
         "type": "object",
@@ -464,37 +464,40 @@
           ] 
         }
       }
-    }
+    },
+    "required": ["geometry"]
   },
-
   
   "Building": {
-    "allOf": [ 
-      { "$ref" : "#/_AbstractCityObject" }, 
-      { "$ref" : "#/_AbstractBuilding" }
-    ],
-    "properties": {
-      "type": { "enum": ["Building"] },
-      "geometry": {}
-    },
-    "required": ["type", "geometry"]
-  },
-
-
-  "BuildingPart": {
     "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBuilding" },
       {
         "properties": {
-          "type": { "enum": ["BuildingPart"] },
-          "parent": {
-            "type": "string",
-            "description": "the ID of the parent Building"
+          "type": { "enum": ["Building"] },
+          "attributes": {
+            "properties": {
+              "test": {"type": "string"}
+            }
           }
         },
-        "required": ["parent"]
+        "required": ["type"]
       }
     ]
+  },
+
+  "BuildingPart": {
+    "allOf": [
+      { "$ref": "#/_AbstractBuilding" }
+    ],
+    "properties": {
+      "type": { "enum": ["BuildingPart"] },
+      "parent": {
+        "type": "string",
+        "description": "the ID of the parent Building"
+      }
+    },
+    "required": ["parent"]
   },
 
   "BuildingInstallation": {

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -14,50 +14,194 @@
     "required": ["type"]
   },
 
-  "CityObjectGroup": {
-    "type": "object",
+  "_AbstractCityObject": {
     "properties": {
-      "type": { "enum": ["CityObjectGroup"] },
       "attributes": {
         "type": "object",
         "properties": {
-          "creationDate" : {"type": "string","format": "date"},
-          "terminationDate" : {"type": "string","format": "date"},
+          "creationDate" : {"type": "string", "format": "date"},
+          "terminationDate" : {"type": "string", "format": "date"},
           "class": {"type": "string"},
           "function": {"type": "string"},
           "usage": {"type": "string"}
         }
-      },
-      "members": {
-        "type": "array",
-        "description": "the IDs of the CityObjects members of that group",
-        "items": {"type": "string"}
       },
       "geographicalExtent": {
         "type": "array",
         "items": { "type": "number" },
         "minItems": 6,    
         "maxItems": 6    
+      }
+    }
+  },
+
+
+  "_AbstractBuilding": {
+    "properties": {
+      "attributes": {
+        "properties": {
+          "measuredHeight": { "type": "number"},
+          "roofType": { "type": "string"},
+          "storeysAboveGround": { "type": "integer"},
+          "storeysBelowGround": { "type": "integer"},
+          "storeyHeightsAboveGround": { 
+            "type": "array",
+            "items": {"type": "number"}
+          },
+          "storeyHeightsBelowGround": { 
+            "type": "array",
+            "items": {"type": "number"}
+          },
+          "yearOfConstruction": { "type": "integer"},
+          "yearOfDemolition": { "type": "integer"}
+        }
+      },
+      "address": {
+        "type": "object",
+        "properties": {
+          "CountryName": {"type": "string"},
+          "LocalityName": {"type": "string"},
+          "ThoroughfareNumber": {"type": "string"},
+          "ThoroughfareName": {"type": "string"},
+          "PostalCode": {"type": "string"},
+          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+        }
+      },
+      "children": {
+        "type": "array",
+        "description": "the IDs of the BuildingPart/Installation of this Building",
+        "items": {"type": "string"}
       },
       "geometry": {
         "type": "array",
         "items": {
           "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
             {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
             {"$ref": "geomprimitives.json#/CompositeSolid"},
             {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"}            
+            {"$ref": "geomtemplates.json#/GeometryInstance"}
           ] 
-        },
-        "minItems": 0,    
-        "maxItems": 1 
+        }
       }
     },
-    "required": ["type", "members"]
+    "required": ["geometry"]
   },
+  
+
+  "Building": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractBuilding" },
+      {
+        "properties": {
+          "type": { "enum": ["Building"] }
+        },
+        "required": ["type"]
+      }
+    ]
+  },
+
+  "BuildingPart": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractBuilding" },
+      {
+        "properties": {
+          "type": { "enum": ["BuildingPart"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          }
+        },
+        "required": ["type", "parent"]
+      }
+    ]
+  },
+
+
+  "BuildingInstallation": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
+        "properties": {
+          "type": { "enum": ["BuildingInstallation"] },
+          "attributes": {
+            "properties": {
+              "measuredHeight": { "type": "number"},
+              "roofType": { "type": "string"},
+              "storeysAboveGround": { "type": "integer"},
+              "storeysBelowGround": { "type": "integer"},
+              "storeyHeightsAboveGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "storeyHeightsBelowGround": { 
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "yearOfConstruction": { "type": "integer"},
+              "yearOfDemolition": { "type": "integer"}
+            }
+          },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},            
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["type", "geometry" , "parent"]
+      }
+    ]
+  },
+
+
+  "CityObjectGroup": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
+        "properties": {
+          "type": { "enum": ["CityObjectGroup"] },
+          "members": {
+            "type": "array",
+            "description": "the IDs of the CityObjects members of that group",
+            "items": {"type": "string"}
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"}            
+              ] 
+            },
+            "minItems": 0,    
+            "maxItems": 1 
+          }
+        },
+        "required": ["type", "members"]
+      }
+    ]
+  },
+
 
   "Tunnel": {
     "type": "object",
@@ -393,172 +537,6 @@
     },
     "required": ["type", "geometry", "parent"],
     "additionalProperties": false
-  },
-
-
-  "_AbstractCityObject": {
-    "properties": {
-      "attributes": {
-        "type": "object",
-        "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      }
-    }
-  },
-
-
-  "_AbstractBuilding": {
-    "properties": {
-      "attributes": {
-        "properties": {
-          "measuredHeight": { "type": "number"},
-          "roofType": { "type": "string"},
-          "storeysAboveGround": { "type": "integer"},
-          "storeysBelowGround": { "type": "integer"},
-          "storeyHeightsAboveGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "storeyHeightsBelowGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the BuildingPart/Installation of this Building",
-        "items": {"type": "string"}
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
-      }
-    },
-    "required": ["geometry"]
-  },
-  
-
-  "Building": {
-    "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
-      { "$ref": "#/_AbstractBuilding" },
-      {
-        "properties": {
-          "type": { "enum": ["Building"] }
-        },
-        "required": ["type"]
-      }
-    ]
-  },
-
-  "BuildingPart": {
-    "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
-      { "$ref": "#/_AbstractBuilding" },
-      {
-        "properties": {
-          "type": { "enum": ["BuildingPart"] },
-          "parent": {
-            "type": "string",
-            "description": "the ID of the parent Building"
-          }
-        },
-        "required": ["type", "parent"]
-      }
-    ]
-  },
-
-
-  "BuildingInstallation": {
-    "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
-      {
-        "properties": {
-          "type": { "enum": ["BuildingInstallation"] },
-          "attributes": {
-            "properties": {
-              "measuredHeight": { "type": "number"},
-              "roofType": { "type": "string"},
-              "storeysAboveGround": { "type": "integer"},
-              "storeysBelowGround": { "type": "integer"},
-              "storeyHeightsAboveGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "storeyHeightsBelowGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "yearOfConstruction": { "type": "integer"},
-              "yearOfDemolition": { "type": "integer"}
-            }
-          },
-          "address": {
-            "type": "object",
-            "properties": {
-              "CountryName": {"type": "string"},
-              "LocalityName": {"type": "string"},
-              "ThoroughfareNumber": {"type": "string"},
-              "ThoroughfareName": {"type": "string"},
-              "PostalCode": {"type": "string"},
-              "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-            }
-          },
-          "parent": {
-            "type": "string",
-            "description": "the ID of the parent Building"
-          },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"$ref": "geomprimitives.json#/MultiPoint"},
-                {"$ref": "geomprimitives.json#/MultiLineString"},
-                {"$ref": "geomprimitives.json#/Solid"},
-                {"$ref": "geomprimitives.json#/MultiSolid"},
-                {"$ref": "geomprimitives.json#/CompositeSolid"},
-                {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomprimitives.json#/CompositeSurface"},            
-                {"$ref": "geomtemplates.json#/GeometryInstance"}
-              ] 
-            }
-          }
-        },
-        "required": ["type", "geometry" , "parent"]
-      }
-    ]
   },
 
 

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -757,161 +757,118 @@
     "additionalProperties": false
   },    
 
+
   "SolitaryVegetationObject": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["SolitaryVegetationObject"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},                        
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "species": {"type": "string"},
-          "trunkDiameter": {"type": "number"},
-          "crownDiameter": {"type": "number"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ]
-        }
+          "type": { "enum": ["SolitaryVegetationObject"] },
+          "attributes": {
+            "properties": {
+              "species": {"type": "string"},
+              "trunkDiameter": {"type": "number"},
+              "crownDiameter": {"type": "number"}
+            }
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
+
 
   "LandUse": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["LandUse"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},                        
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"}
-          ]
-        }
+          "type": { "enum": ["LandUse"] },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
+
 
   "CityFurniture": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["CityFurniture"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ]
-        }
+          "type": { "enum": ["CityFurniture"] },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
 
+
   "GenericCityObject": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["GenericCityObject"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ]
-        }
+          "type": { "enum": ["GenericCityObject"] },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   }
+
 
 }

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -486,73 +486,19 @@
   },
 
   "BuildingPart": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["BuildingPart"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractBuilding" },
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "measuredHeight": { "type": "number"},
-          "roofType": { "type": "string"},
-          "storeysAboveGround": { "type": "integer"},
-          "storeysBelowGround": { "type": "integer"},
-          "storeyHeightsAboveGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "storeyHeightsBelowGround": { 
-            "type": "array",
-            "items": {"type": "number"}
-          },
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+          "type": { "enum": ["BuildingPart"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Building"
+          }
         },
-        "additionalProperties": false
-      },              
-      "children": {
-        "type": "array",
-          "items": {"type": "string"}
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Building"
-      },      
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+        "required": ["parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
+    ]
   },
 
   "BuildingInstallation": {

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -395,10 +395,9 @@
     "additionalProperties": false
   },
 
-  "Building": {
+  "_AbstractBuilding": {
     "type": "object",
     "properties": {
-      "type": { "enum": ["Building"] },
       "attributes": {
         "type": "object",
         "properties": {
@@ -457,8 +456,19 @@
         }
       }
     },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    "required": ["geometry"]
+  },
+
+  "Building": {
+    "allOf": [
+      { "$ref" : "#/_AbstractBuilding"},
+      {
+        "properties": {
+          "type": { "enum": ["Building"] }
+        },
+        "required": ["type"]
+      }
+    ]
   },
 
   "BuildingPart": {

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -203,32 +203,18 @@
   },
 
 
-  "Tunnel": {
-    "type": "object",
+  "_AbstractTunnel": {
     "properties": {
-      "type": { "enum": ["Tunnel"] },
       "attributes": {
-        "type": "object",
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
           "yearOfConstruction": { "type": "integer"},
           "yearOfDemolition": { "type": "integer"}
         }
       },
       "children": {
         "type": "array",
-        "description": "the IDs of the TunnelPart and TunnelInstallation of this Tunnel",
+        "description": "the IDs of the TunnelPart/Installation of this Tunnel",
         "items": {"type": "string"}
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
       },
       "geometry": {
         "type": "array",
@@ -242,100 +228,72 @@
         }
       }
     },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
-  },    
+    "required": ["geometry"]
+  },
+  
+
+  "Tunnel": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractTunnel" },
+      {
+        "properties": {
+          "type": { "enum": ["Tunnel"] }
+        },
+        "required": ["type"]
+      }
+    ]
+  },
 
   "TunnelPart": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["TunnelPart"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractTunnel" },
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Tunnel"
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the TunnelInstallation of this TunnelPart",
-        "items": {"type": "string"}
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["TunnelPart"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Tunnel"
+          }
+        },
+        "required": ["type", "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
+    ]
   },
 
+
   "TunnelInstallation": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["TunnelInstallation"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},            
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "parent": {
-        "type": "string",
-        "description": "the ID of the parent Tunnel"
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiPoint"},
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},            
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ] 
-        }
+          "type": { "enum": ["TunnelInstallation"] },
+          "parent": {
+            "type": "string",
+            "description": "the ID of the parent Tunnel"
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiPoint"},
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},            
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ] 
+            }
+          }
+        },
+        "required": ["type", "geometry" , "parent"]
       }
-    },
-    "required": ["type", "geometry", "parent"],
-    "additionalProperties": false
+    ]
   },
+ 
 
   "Bridge": {
     "type": "object",
@@ -541,221 +499,166 @@
 
 
   "Road": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["Road"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "surfaceMaterial": { 
+          "type": { "enum": ["Road"] },
+          "attributes": {
+            "properties": {
+              "surfaceMaterial": { 
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          },
+          "geometry": {
             "type": "array",
-            "items": {"type": "string"}
-          }
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"}
-          ]
-        }
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
 
+
   "Railway": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["Railway"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "surfaceMaterial": { 
+          "type": { "enum": ["Railway"] },
+          "attributes": {
+            "properties": {
+              "surfaceMaterial": { 
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          },
+          "geometry": {
             "type": "array",
-            "items": {"type": "string"}
-          }
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"}
-          ]
-        }
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
 
   "TransportSquare": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["TransportSquare"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "surfaceMaterial": { 
+          "type": { "enum": ["TransportSquare"] },
+          "attributes": {
+            "properties": {
+              "surfaceMaterial": { 
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          },
+          "geometry": {
             "type": "array",
-            "items": {"type": "string"}
-          }
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ]
-        }
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},
+                {"$ref": "geomtemplates.json#/GeometryInstance"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },  
 
+
   "TINRelief": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["TINRelief"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },        
-      "geometry": {
-        "type": "array",
-        "items": {"$ref": "geomprimitives.json#/CompositeSurface"}
+          "type": { "enum": ["TINRelief"] },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
+
 
   "WaterBody": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["WaterBody"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},                        
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiLineString"},
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"}
-          ]
-        }
+          "type": { "enum": ["WaterBody"] },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiLineString"},
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
+    ]
   },
 
+
   "PlantCover": {
-    "type": "object",
-    "properties": {
-      "type": { "enum": ["PlantCover"] },
-      "attributes": {
-        "type": "object",
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "creationDate" : {"type": "string", "format": "date"},
-          "terminationDate" : {"type": "string", "format": "date"},                        
-          "class": {"type": "string"},
-          "function": {"type": "string"},
-          "usage": {"type": "string"},
-          "averageHeight": {"type": "number"}
-        }
-      },
-      "geographicalExtent": {
-        "type": "array",
-        "items": { "type": "number" },
-        "minItems": 6,    
-        "maxItems": 6    
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/MultiSolid"},
-            {"$ref": "geomtemplates.json#/GeometryInstance"}
-          ]
-        }
+          "type": { "enum": ["PlantCover"] },
+          "attributes": {
+            "properties": {
+              "averageHeight": {"type": "number"}
+            }
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSolid"},
+                {"$ref": "geomprimitives.json#/MultiSurface"}
+              ]
+            }
+          }        
+        },
+        "required": ["type", "geometry"]
       }
-    },
-    "required": ["type", "geometry"],
-    "additionalProperties": false
-  },    
+    ]
+  },  
 
 
   "SolitaryVegetationObject": {

--- a/schema/v09/geomprimitives.json
+++ b/schema/v09/geomprimitives.json
@@ -28,9 +28,6 @@
   },
 
 
-          
-
-
   "Solid": {
     "type": "object",
     "properties": {
@@ -114,7 +111,8 @@
         }
       }
     },
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
 
   "MultiSolid": {
@@ -212,8 +210,10 @@
         }                
       }
     },
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
+
 
   "CompositeSolid": {
     "type": "object",
@@ -310,8 +310,10 @@
         }                
       }
     },        
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
+
 
   "MultiSurface": {
     "type": "object",
@@ -384,8 +386,10 @@
         }
       }
     },       
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
+
 
   "CompositeSurface": {
     "type": "object",
@@ -462,8 +466,10 @@
         }
       }        
     },        
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
+
 
   "MultiLineString": {
     "type": "object",
@@ -482,8 +488,10 @@
         }
       }
     },        
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   },
+
 
   "MultiPoint": {
     "type": "object",
@@ -499,7 +507,8 @@
          "items": {"type": "integer"}
       }
     },
-    "required": ["type", "lod", "boundaries"]
+    "required": ["type", "lod", "boundaries"],
+    "additionalProperties": false
   }
 
 }


### PR DESCRIPTION
I propose this way for the definition of city object types. The idea is that we can introduce abstract types (denoted as ``_AbstractType``) which define the basic properties of the objects and, then, there is a simple concrete type that include those properties and only adds the ``type`` property (e.g., see ``_AbstractBuilding`` and ``Building`` in 7b94613ba7cde9a99f9b546835ca2d13ca57158b).

There are certain benefits:
- We avoid redundancy. In fact, all common attributes of city objects can be in a ``_AbstractCityObject``, which all city objects extend. In addition, for complex types such as ``BuildingParts`` we can reuse parts from existing objects (e.g., see ab534166262f34607269ad5e963e49304ad9f54f).
- We provide an easy way to extend existing objects through extensions (related to issue #31). If someone wants to add properties to the ``Building`` without specifying a new type they can simply extend the ``Building`` object. If they want to make a new building type, though, they can extend the ``_AbstractBuilding`` and just add their own ``type`` property. In any case, they don't have to rewrite all properties of the original class.

As a caveat, though, we can't use the ``additionalProperties: false`` option with this mechanism (see why [here](https://github.com/json-schema-org/json-schema-org.github.io/issues/148)), therefore we cannot force objects to only have the properties of the schema. There is a workaround, by listing again all "inherited" properties in the last class (explained at the end of [this](https://github.com/json-schema-org/json-schema-org.github.io/issues/148#issuecomment-331948341) answer). Nevertheless, I believe it's better to just warn users about this through cjio validation, than really forcing them to follow the schema. After all, the whole point of JSON is to be more flexible.