### PR TITLE
Some proposed fixes for v09 beta schemas

### DIFF
--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -400,31 +400,39 @@
   }, 
 
 
+  "_AbstractTransportationComplex": {
+    "properties": {
+      "attributes": {
+        "properties": {
+          "surfaceMaterial": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        }
+      },
+      "geometry": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {"$ref": "geomprimitives.json#/MultiSurface"},
+            {"$ref": "geomprimitives.json#/CompositeSurface"}
+          ] 
+        }
+      }
+    },
+    "required": ["geometry"]
+  },
+  
+  
   "Road": {
     "allOf": [
       { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {
-          "type": { "enum": ["Road"] },
-          "attributes": {
-            "properties": {
-              "surfaceMaterial": { 
-                "type": "array",
-                "items": {"type": "string"}
-              }
-            }
-          },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomprimitives.json#/CompositeSurface"}
-              ]
-            }
-          }        
+          "type": { "enum": ["Road"] }
         },
-        "required": ["type", "geometry"]
+        "required": ["type"]
       }
     ]
   },
@@ -433,28 +441,12 @@
   "Railway": {
     "allOf": [
       { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {
-          "type": { "enum": ["Railway"] },
-          "attributes": {
-            "properties": {
-              "surfaceMaterial": { 
-                "type": "array",
-                "items": {"type": "string"}
-              }
-            }
-          },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomprimitives.json#/CompositeSurface"}
-              ]
-            }
-          }        
+          "type": { "enum": ["Railway"] }
         },
-        "required": ["type", "geometry"]
+        "required": ["type"]
       }
     ]
   },
@@ -462,28 +454,12 @@
   "TransportSquare": {
     "allOf": [
       { "$ref": "#/_AbstractCityObject"},
+      { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {
-          "type": { "enum": ["TransportSquare"] },
-          "attributes": {
-            "properties": {
-              "surfaceMaterial": { 
-                "type": "array",
-                "items": {"type": "string"}
-              }
-            }
-          },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomprimitives.json#/CompositeSurface"}
-              ]
-            }
-          }        
+          "type": { "enum": ["TransportSquare"] }       
         },
-        "required": ["type", "geometry"]
+        "required": ["type"]
       }
     ]
   },  

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -478,8 +478,7 @@
             "items": {
               "oneOf": [
                 {"$ref": "geomprimitives.json#/MultiSurface"},
-                {"$ref": "geomprimitives.json#/CompositeSurface"},
-                {"$ref": "geomtemplates.json#/GeometryInstance"}
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
               ]
             }
           }        

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -124,24 +124,6 @@
       {
         "properties": {
           "type": { "enum": ["BuildingInstallation"] },
-          "attributes": {
-            "properties": {
-              "measuredHeight": { "type": "number"},
-              "roofType": { "type": "string"},
-              "storeysAboveGround": { "type": "integer"},
-              "storeysBelowGround": { "type": "integer"},
-              "storeyHeightsAboveGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "storeyHeightsBelowGround": { 
-                "type": "array",
-                "items": {"type": "number"}
-              },
-              "yearOfConstruction": { "type": "integer"},
-              "yearOfDemolition": { "type": "integer"}
-            }
-          },
           "parent": {
             "type": "string",
             "description": "the ID of the parent Building"

--- a/schema/v09/cityobjects.json
+++ b/schema/v09/cityobjects.json
@@ -37,59 +37,63 @@
 
 
   "_AbstractBuilding": {
-    "properties": {
-      "attributes": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "measuredHeight": { "type": "number"},
-          "roofType": { "type": "string"},
-          "storeysAboveGround": { "type": "integer"},
-          "storeysBelowGround": { "type": "integer"},
-          "storeyHeightsAboveGround": { 
-            "type": "array",
-            "items": {"type": "number"}
+          "attributes": {
+            "properties": {
+              "measuredHeight": { "type": "number"},
+              "roofType": { "type": "string"},
+              "storeysAboveGround": { "type": "integer"},
+              "storeysBelowGround": { "type": "integer"},
+              "storeyHeightsAboveGround": {
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "storeyHeightsBelowGround": {
+                "type": "array",
+                "items": {"type": "number"}
+              },
+              "yearOfConstruction": { "type": "integer"},
+              "yearOfDemolition": { "type": "integer"}
+            }
           },
-          "storeyHeightsBelowGround": { 
-            "type": "array",
-            "items": {"type": "number"}
+          "address": {
+            "type": "object",
+            "properties": {
+              "CountryName": {"type": "string"},
+              "LocalityName": {"type": "string"},
+              "ThoroughfareNumber": {"type": "string"},
+              "ThoroughfareName": {"type": "string"},
+              "PostalCode": {"type": "string"},
+              "location": {"$ref": "geomprimitives.json#/MultiPoint"}
+            }
           },
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "address": {
-        "type": "object",
-        "properties": {
-          "CountryName": {"type": "string"},
-          "LocalityName": {"type": "string"},
-          "ThoroughfareNumber": {"type": "string"},
-          "ThoroughfareName": {"type": "string"},
-          "PostalCode": {"type": "string"},
-          "location": {"$ref": "geomprimitives.json#/MultiPoint"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the BuildingPart/Installation of this Building",
-        "items": {"type": "string"}
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"}
-          ] 
-        }
+          "children": {
+            "type": "array",
+            "description": "the IDs of the BuildingPart/Installation of this Building",
+            "items": {"type": "string"}
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"}
+              ]
+            }
+          }
+        },
+        "required": ["geometry"]
       }
-    },
-    "required": ["geometry"]
+    ]
   },
   
 
   "Building": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBuilding" },
       {
         "properties": {
@@ -102,7 +106,6 @@
 
   "BuildingPart": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBuilding" },
       {
         "properties": {
@@ -185,36 +188,40 @@
 
 
   "_AbstractTunnel": {
-    "properties": {
-      "attributes": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "yearOfConstruction": { "type": "integer"},
-          "yearOfDemolition": { "type": "integer"}
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the TunnelPart/Installation of this Tunnel",
-        "items": {"type": "string"}
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"}
-          ] 
-        }
+          "attributes": {
+            "properties": {
+              "yearOfConstruction": { "type": "integer"},
+              "yearOfDemolition": { "type": "integer"}
+            }
+          },
+          "children": {
+            "type": "array",
+            "description": "the IDs of the TunnelPart/Installation of this Tunnel",
+            "items": {"type": "string"}
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"}
+              ]
+            }
+          }
+        },
+        "required": ["geometry"]
       }
-    },
-    "required": ["geometry"]
+    ]
   },
   
 
   "Tunnel": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractTunnel" },
       {
         "properties": {
@@ -227,7 +234,6 @@
 
   "TunnelPart": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractTunnel" },
       {
         "properties": {
@@ -276,37 +282,41 @@
 
 
   "_AbstractBridge": {
-    "properties": {
-      "attributes": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "yearOfConstruction": {"type": "integer"},
-          "yearOfDemolition": {"type": "integer"},
-          "isMovable": {"type": "boolean" }
-        }
-      },
-      "children": {
-        "type": "array",
-        "description": "the IDs of the Bridge/Part/Installation/CE of this Bridge",
-        "items": {"type": "string"}
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/Solid"},
-            {"$ref": "geomprimitives.json#/CompositeSolid"}
-          ] 
-        }
+          "attributes": {
+            "properties": {
+              "yearOfConstruction": {"type": "integer"},
+              "yearOfDemolition": {"type": "integer"},
+              "isMovable": {"type": "boolean" }
+            }
+          },
+          "children": {
+            "type": "array",
+            "description": "the IDs of the Bridge/Part/Installation/CE of this Bridge",
+            "items": {"type": "string"}
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/Solid"},
+                {"$ref": "geomprimitives.json#/CompositeSolid"}
+              ]
+            }
+          }
+        },
+        "required": ["geometry"]
       }
-    },
-    "required": ["geometry"]
+    ]
   },
   
 
   "Bridge": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBridge" },
       {
         "properties": {
@@ -320,7 +330,6 @@
 
   "BridgePart": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractBridge" },
       {
         "properties": {
@@ -401,32 +410,36 @@
 
 
   "_AbstractTransportationComplex": {
-    "properties": {
-      "attributes": {
+    "allOf": [
+      { "$ref": "#/_AbstractCityObject"},
+      {
         "properties": {
-          "surfaceMaterial": {
+          "attributes": {
+            "properties": {
+              "surfaceMaterial": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          },
+          "geometry": {
             "type": "array",
-            "items": {"type": "string"}
+            "items": {
+              "oneOf": [
+                {"$ref": "geomprimitives.json#/MultiSurface"},
+                {"$ref": "geomprimitives.json#/CompositeSurface"}
+              ]
+            }
           }
-        }
-      },
-      "geometry": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {"$ref": "geomprimitives.json#/MultiSurface"},
-            {"$ref": "geomprimitives.json#/CompositeSurface"}
-          ] 
-        }
+        },
+        "required": ["geometry"]
       }
-    },
-    "required": ["geometry"]
+    ]
   },
   
   
   "Road": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {
@@ -440,7 +453,6 @@
 
   "Railway": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {
@@ -453,7 +465,6 @@
 
   "TransportSquare": {
     "allOf": [
-      { "$ref": "#/_AbstractCityObject"},
       { "$ref": "#/_AbstractTransportationComplex" },
       {
         "properties": {


### PR DESCRIPTION
While going through the v09 beta schemas, I found some issues.

1. `BuildingInstallation` has the same attributes as `Building`. Since this was not the case in v06 and v08 (and is also not the case in the CityGML data model), I removed these attributes.

2. According to the v08 spec, `TransportSquare` should have the same geometries as `Road` and `Railway` (`MultiSurface` and `CompositeSurface`). But it additionally has `GeometryInstance`, so I removed this one. 

3. Since `Road,` `Railway,` and `TransportSquare` have the same attributes and geometries (after step 2), I added a new abstract type `_AbstractTransportationComplex` (which is inline with the CityGML model as well).

4. Abstract types like `_AbstractBuilding` or `_AbstractBridge` do not inherit the attributes from `_AbstractCityObject.` In constrast, the concrete type `Building` then inherits from both `_AbstractCityObject` and `_AbstractBuilding.` 

    Fixed this so that `_AbstractBuilding` now inherits from `_AbstractCityObject,` and `Building` from `_AbstractBuilding.` I think this is important because if someone wants to create a new building type in an extension and if they want to extend from `_AbstractBuilding` for this purpose, they now inherit the common attributes from `_AbstractCityObject` as well.